### PR TITLE
feat: add optional SAFE report link to GitHub issues (#11)

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -15,6 +15,11 @@ on:
         description: 'Maximum issues to create'
         type: number
         default: 10
+      report-url:
+        description: 'URL to the full SAFE report (e.g. GitHub Actions run URL). When provided, a download link is added to each issue.'
+        required: false
+        type: string
+        default: ''
       level:
         description: 'Only include policies with rl-level >= this value (1-5)'
         type: number
@@ -50,4 +55,5 @@ jobs:
             --report "${{ inputs.report-path }}" \
             --metadata-dir "${{ inputs.metadata-dir || '_tool/data/rl-scanner-metadata/data' }}" \
             --max-issues ${{ inputs.max-issues }} \
+            ${{ inputs.report-url && format('--report-url "{0}"', inputs.report-url) || '' }} \
             ${{ inputs.level && format('--level {0}', inputs.level) || '' }}

--- a/.github/workflows/scan-and-create-issues.yml
+++ b/.github/workflows/scan-and-create-issues.yml
@@ -63,7 +63,7 @@ jobs:
                 --rl-store=/tmp/__rlsecure/rlstore \
                 --purl=pkg:rl/test/rl-scanner-to-github@${{ github.sha }} \
                 --output-path=/report \
-                --format=rl-json
+                --format=rl-json,rl-html
 
               chmod -R a+rX /report
 
@@ -102,4 +102,5 @@ jobs:
           python src/main.py \
             --report ./rl-reports/report.rl.json \
             --metadata-dir data/rl-scanner-metadata/data \
-            --max-issues 5
+            --max-issues 5 \
+            --report-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/src/main.py
+++ b/src/main.py
@@ -11,14 +11,25 @@ from parse_report import BlockingPolicy, parse_report
 from policy_config import filter_policies, find_policy_config, load_policy_config
 
 
-def build_body(policy: BlockingPolicy, metadata: dict | None, cve_details: dict) -> str:
+def build_body(
+    policy: BlockingPolicy, metadata: dict | None, cve_details: dict, report_url=None
+) -> str:
     """Build issue body markdown."""
-    lines = [
-        f"**Severity:** {policy.severity}",
-        f"**Priority:** P{policy.priority}",
-        f"**Effort:** {policy.effort}",
-        "",
-    ]
+    lines = []
+
+    if report_url:
+        lines.append(f"> 📊 [Download full SAFE report]({report_url})")
+        lines.append("> _Download the artifact, unzip, and open `rl-html/sdlc.html`_")
+        lines.append("")
+
+    lines.extend(
+        [
+            f"**Severity:** {policy.severity}",
+            f"**Priority:** P{policy.priority}",
+            f"**Effort:** {policy.effort}",
+            "",
+        ]
+    )
     if metadata and metadata.get("description"):
         lines.extend([metadata["description"], ""])
 
@@ -70,6 +81,12 @@ def main() -> int:
         help="Only include policies with rl-level >= this value",
     )
     parser.add_argument("--policy-config", help="Path to policy config file (.info)")
+    parser.add_argument(
+        "--report-url",
+        default=None,
+        help="URL to the full SAFE report (e.g. GitHub Actions run URL). "
+        "When provided, a download link is added to each issue body.",
+    )
     args = parser.parse_args()
 
     if args.level and not args.metadata_dir:
@@ -125,7 +142,7 @@ def main() -> int:
         meta = metadata.get(policy.policy_id)
         label = meta["label"] if meta and meta.get("label") else policy.policy_id
         title = f"[{policy.policy_id}] {label}"
-        body = build_body(policy, meta, result.cve_details)
+        body = build_body(policy, meta, result.cve_details, report_url=args.report_url)
 
         if args.dry_run:
             print(f"\n{'='*60}")

--- a/tests/test_build_body.py
+++ b/tests/test_build_body.py
@@ -1,0 +1,49 @@
+"""Tests for build_body() in main.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from main import build_body
+from parse_report import BlockingPolicy, Component
+
+
+def _make_policy():
+    """Create a minimal BlockingPolicy for build_body tests."""
+    return BlockingPolicy(
+        policy_id="SQ31102",
+        category="vulnerabilities",
+        severity="high",
+        priority=0,
+        effort="high",
+        components=[Component(name="libssl.so", path="/lib/libssl.so.1.1")],
+        cve_ids=["CVE-2024-1234"],
+    )
+
+
+def test_build_body_without_report_url():
+    body = build_body(_make_policy(), None, {})
+    assert "SAFE report" not in body
+    assert "\U0001f4ca" not in body
+    assert body.lstrip().startswith("**Severity:**")
+
+
+def test_build_body_with_report_url():
+    url = "https://github.com/org/repo/actions/runs/12345"
+    body = build_body(_make_policy(), None, {}, report_url=url)
+    assert body.startswith("> \U0001f4ca")
+    assert url in body
+    assert "[Download full SAFE report]" in body
+    assert "sdlc.html" in body
+    assert "**Severity:** high" in body
+
+
+def test_build_body_with_report_url_none_explicitly():
+    body = build_body(_make_policy(), None, {}, report_url=None)
+    assert "SAFE report" not in body
+
+
+def test_build_body_with_empty_string_report_url():
+    body = build_body(_make_policy(), None, {}, report_url="")
+    assert "SAFE report" not in body

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -14,6 +14,7 @@ WORKFLOW_TO_CLI = {
     "report-path": "--report",
     "metadata-dir": "--metadata-dir",
     "max-issues": "--max-issues",
+    "report-url": "--report-url",
     "level": "--level",
 }
 
@@ -40,7 +41,7 @@ def _load_workflow_run_step() -> str:
 def test_workflow_has_required_inputs():
     """YAML defines exactly: report-path, metadata-dir, max-issues, level."""
     inputs = _load_workflow_inputs()
-    expected = {"report-path", "metadata-dir", "max-issues", "level"}
+    expected = {"report-path", "metadata-dir", "max-issues", "report-url", "level"}
     assert set(inputs.keys()) == expected
 
 
@@ -79,3 +80,9 @@ def test_workflow_step_passes_all_inputs():
     run_step = _load_workflow_run_step()
     for input_name in inputs:
         assert f"inputs.{input_name}" in run_step, f"Input '{input_name}' not passed in run step"
+
+
+def test_report_url_is_optional():
+    """report-url has required: false."""
+    inputs = _load_workflow_inputs()
+    assert inputs["report-url"].get("required") is False


### PR DESCRIPTION
Add --report-url CLI arg and matching workflow input that prepends a download link to the full SAFE report at the top of each issue body. Off by default — no change to existing behavior when omitted.

- src/main.py: new --report-url arg, build_body() prepends blockquote link
- create-issues.yml: new optional report-url input, passed conditionally
- scan-and-create-issues.yml: enable feature with Actions run URL, add rl-html format
- tests: 5 new tests (build_body + workflow sync), all 68 pass